### PR TITLE
Adds the possibility to define help text for parameters

### DIFF
--- a/usecases/usecase/usecase.py
+++ b/usecases/usecase/usecase.py
@@ -3,7 +3,7 @@ import argparse
 from dataclasses import dataclass
 from typing import Dict, Type
 
-from utils.configurable import get_parameters, ParameterDefinitions, build_parser, get_arguments
+from utils.configurable import ParameterDefinitions, build_parser, get_arguments, get_class_parameters
 
 
 class UseCase(abc.ABC):
@@ -66,7 +66,7 @@ def use_case(name: str, desc: str):
     def inner(cls: Type[UseCase]):
         if name in use_cases:
             raise IndexError(f"Use case with name {name} already exists")
-        use_cases[name] = _WrappedUseCase(name, desc, cls, get_parameters(cls.__init__, name))
+        use_cases[name] = _WrappedUseCase(name, desc, cls, get_class_parameters(cls, name))
 
         return cls
 

--- a/utils/db_storage/db_storage.py
+++ b/utils/db_storage/db_storage.py
@@ -1,11 +1,11 @@
 import sqlite3
 
-from utils.configurable import configurable
+from utils.configurable import configurable, parameter
 
 
 @configurable("db_storage", "Stores the results of the experiments in a SQLite database")
 class DbStorage:
-    def __init__(self, connection_string: str = ":memory:"):
+    def __init__(self, connection_string: str = parameter(desc="sqlite3 database connection string for logs", default=":memory:")):
         self.connection_string = connection_string
 
     def init(self):

--- a/utils/openai/openai_llm.py
+++ b/utils/openai/openai_llm.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import tiktoken
 
-from utils.configurable import configurable
+from utils.configurable import configurable, parameter
 from utils.llm_util import LLMResult, LLM
 
 
@@ -20,13 +20,13 @@ class OpenAIConnection(LLM):
     If you really must use it, you can import it directly from the utils.openai.openai_llm module, which will later on
     show you, that you did not specialize yet.
     """
-    api_key: str
-    model: str
-    context_size: int
-    api_url: str = "https://api.openai.com"
-    api_timeout: int = 240
-    api_backoff: int = 60
-    api_retries: int = 3
+    api_key: str = parameter(desc="OpenAI API Key")
+    model: str = parameter(desc="OpenAI model name")
+    context_size: int = parameter(desc="Maximum context size for the model, only used internally for things like trimming to the context size")
+    api_url: str = parameter(desc="URL of the OpenAI API", default="https://api.openai.com")
+    api_timeout: int = parameter(desc="Timeout for the API request", default=240)
+    api_backoff: int = parameter(desc="Backoff time in seconds when running into rate-limits", default=60)
+    api_retries: int = parameter(desc="Number of retries when running into rate-limits", default=3)
 
     def get_response(self, prompt, *, retry: int = 0, **kwargs) -> LLMResult:
         if retry >= self.api_retries:

--- a/wintermute.py
+++ b/wintermute.py
@@ -10,7 +10,7 @@ def main():
     for name, use_case in use_cases.items():
         use_case.build_parser(subparser.add_parser(
             name=use_case.name,
-            description=use_case.description
+            help=use_case.description
         ))
 
     parsed = parser.parse_args(sys.argv[1:])


### PR DESCRIPTION
With this change help text descriptions can now be defined for @configurable parameters. 

The `parameter` function has been strongly tied to the `dataclasses.field` function to support interoperability with existing tools, while also allowing the use of it in "normal" constructors of non-dataclass classes.