### PR TITLE
Adds support for generic text parsing of capabilities

### DIFF
--- a/capabilities/psexec_test_credential.py
+++ b/capabilities/psexec_test_credential.py
@@ -11,7 +11,7 @@ class PSExecTestCredential(Capability):
     conn: PSExecConnection
 
     def describe(self) -> str:
-        return f"give credentials to be tested by stating `{self.get_name()} username password`"
+        return f"give credentials to be tested"
 
     def get_name(self) -> str:
         return "test_credential"

--- a/capabilities/ssh_run_command.py
+++ b/capabilities/ssh_run_command.py
@@ -18,18 +18,16 @@ GOT_ROOT_REXEXPs = [
 @dataclass
 class SSHRunCommand(Capability):
     conn: SSHConnection
+    timeout: int = 10
 
     def describe(self) -> str:
-        return f"give a command to be executed by stating `{self.get_name()} command arguments` and I will respond with the terminal output when running this command over SSH on the linux machine. The given command must not require user interaction."
+        return f"give a command to be executed and I will respond with the terminal output when running this command over SSH on the linux machine. The given command must not require user interaction."
 
     def get_name(self):
         return "exec_command"
 
-    def __call__(self, command: str, timeout:int=10) -> Tuple[str, bool]:
+    def __call__(self, command: str) -> Tuple[str, bool]:
         got_root = False
-
-        cmd_parts = command.split(" ", 1)
-        command = cmd_parts[1]
 
         sudo_pass = Responder(
             pattern=r'\[sudo\] password for ' + self.conn.username + ':',
@@ -39,7 +37,7 @@ class SSHRunCommand(Capability):
         out = StringIO()
 
         try:
-            resp = self.conn.run(command, pty=True, warn=True, out_stream=out, watchers=[sudo_pass], timeout=timeout)
+            resp = self.conn.run(command, pty=True, warn=True, out_stream=out, watchers=[sudo_pass], timeout=self.timeout)
         except Exception as e:
             print("TIMEOUT! Could we have become root?")
         out.seek(0)

--- a/capabilities/ssh_test_credential.py
+++ b/capabilities/ssh_test_credential.py
@@ -12,19 +12,13 @@ class SSHTestCredential(Capability):
     conn: SSHConnection
 
     def describe(self) -> str:
-        return f"give credentials to be tested by stating `{self.get_name()} username password`"
+        return f"give credentials to be tested"
 
     def get_name(self):
         return "test_credential"
 
-    def __call__(self, command: str) -> Tuple[str, bool]:
-        cmd_parts = command.split(" ")
-        assert (cmd_parts[0] == self.get_name())
-
-        if len(cmd_parts) != 3:
-            return "didn't provide username/password", False
-
-        test_conn = self.conn.new_with(username=cmd_parts[1], password=cmd_parts[2])
+    def __call__(self, username: str, password: str) -> Tuple[str, bool]:
+        test_conn = self.conn.new_with(username=username, password=password)
         try:
             test_conn.init()
             user = test_conn.run("whoami")[0].strip('\n\r ')

--- a/usecases/agents.py
+++ b/usecases/agents.py
@@ -1,26 +1,27 @@
+from abc import ABC
 from dataclasses import dataclass, field
 from typing import Dict
 
-from capabilities.capability import Capability
+from capabilities.capability import Capability, capabilities_to_simple_text_handler
 from usecases.common_patterns import RoundBasedUseCase
 
 
 @dataclass
-class Agent(RoundBasedUseCase):
-
+class Agent(RoundBasedUseCase, ABC):
     _capabilities: Dict[str, Capability] = field(default_factory=dict)
     _default_capability: Capability = None
 
     def init(self):
         super().init()
 
-    def add_capability(self, cap:Capability, default:bool=False):
+    def add_capability(self, cap: Capability, default: bool = False):
         self._capabilities[cap.get_name()] = cap
         if default:
             self._default_capability = cap
 
-    def get_capability(self, name:str) -> Capability:
+    def get_capability(self, name: str) -> Capability:
         return self._capabilities.get(name, self._default_capability)
 
     def get_capability_block(self) -> str:
-        return "You can either\n\n" + "\n".join(map(lambda i: f"- {i.describe()}", self._capabilities.values()))
+        capability_descriptions, _parser = capabilities_to_simple_text_handler(self._capabilities)
+        return "You can either\n\n" + "\n".join(f"- {description}" for description in capability_descriptions.values())

--- a/usecases/privesc/common.py
+++ b/usecases/privesc/common.py
@@ -6,6 +6,7 @@ from mako.template import Template
 from rich.panel import Panel
 
 from capabilities import Capability
+from capabilities.capability import capabilities_to_simple_text_handler
 from usecases.agents import Agent
 from utils import llm_util, ui
 from utils.cli_history import SlidingCliHistory
@@ -48,10 +49,13 @@ class Privesc(Agent):
 
         with self.console.status("[bold green]Executing that command..."):
             self.console.print(Panel(answer.result, title="[bold cyan]Got command from LLM:"))
-            capability = cmd.split(" ", 1)[0]
-            result, got_root = self.get_capability(capability)(cmd)
-            if capability == "exec_command":
-                cmd = cmd[len(capability)+1:]
+            _capability_descriptions, parser = capabilities_to_simple_text_handler(self._capabilities, default_capability=self._default_capability)
+            success, *output = parser(cmd)
+            if not success:
+                self.console.print(Panel(output[0], title=f"[bold red]Error parsing command:"))
+                return False
+
+            capability, cmd, (result, got_root) = output
 
         # log and output the command and its result
         self.log_db.add_log_query(self._run_id, turn, cmd, result, answer)

--- a/usecases/privesc/linux.py
+++ b/usecases/privesc/linux.py
@@ -104,7 +104,7 @@ class PrivescWithLSE(UseCase):
 
         run_cmd = "wget -q 'https://github.com/diego-treitos/linux-smart-enumeration/releases/latest/download/lse.sh' -O lse.sh;chmod 700 lse.sh; ./lse.sh -c -i -l 0 | grep -v 'nope$' | grep -v 'skip$'"
 
-        result, got_root = SSHRunCommand(conn=self.conn)(run_cmd, timeout=120)
+        result, got_root = SSHRunCommand(conn=self.conn, timeout=120)(run_cmd)
 
         self.console.print("[yellow]got the output: " + result)
         cmd = self.llm.get_response(template_lse, lse_output=result, number=3)

--- a/utils/configurable.py
+++ b/utils/configurable.py
@@ -114,7 +114,7 @@ def get_parameters(fun, basename: str, fields: Dict[str, dataclasses.Field] = No
 
         if hasattr(type, "__parameters__"):
             params[name] = ComplexParameterDefinition(name, type, default, description, get_class_parameters(type, f"{basename}.{fun.__name__}"))
-        elif type in (str, int, bool):
+        elif type in (str, int, float, bool):
             params[name] = ParameterDefinition(name, type, default, description)
         else:
             raise ValueError(f"Parameter {name} of {basename}.{fun.__name__} must have str, int, bool, or a __parameters__ class as type, not {type}")


### PR DESCRIPTION
This tries to unify the capability handling, though it is not yet optimal for string parameters, as it strictly splits by whitespace. Though it handles dangling "parameters" by only splitting into as many parts as there are parameters of the function, all remaining content is put into the last parameter.

However, as of my testing, the privesc usecases seem to work with it, and it would ease the integration of new capabilities into them.