### PR TITLE
docs: fix CLI errors, use PascalCase args

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,17 +186,17 @@ The next important part is having a machine that we can run our agent against. I
 
 We are using vulnerable Linux systems running in Virtual Machines for this. Never run this against real systems.
 
-{% callout title="We also provide vulnerable machines!" %}
-We are using virtual machines from our [Linux Privilege-Escalation Benchmark](https://github.com/ipa-lab/benchmark-privesc-linux) project. Feel free to use them for your own research!
-{% /callout %}
+> 💡 **We also provide vulnerable machines!**
+>
+> We are using virtual machines from our [Linux Privilege-Escalation Benchmark](https://github.com/ipa-lab/benchmark-privesc-linux) project. Feel free to use them for your own research!
 
 ## Run the Hacking Agent
 
 Finally we can run hackingBuddyGPT against our provided test VM. Enjoy!
 
-{% callout type="warning" title="Don't be evil!" %}
-Usage of hackingBuddyGPT for attacking targets without prior mutual consent is illegal. It's the end user's responsibility to obey all applicable local, state and federal laws. Developers assume no liability and are not responsible for any misuse or damage caused by this program. Only use for educational purposes.
-{% /callout %}
+> ❗ **Don't be evil!**
+>
+> Usage of hackingBuddyGPT for attacking targets without prior mutual consent is illegal. It's the end user's responsibility to obey all applicable local, state and federal laws. Developers assume no liability and are not responsible for any misuse or damage caused by this program. Only use for educational purposes.
 
 With that out of the way, let's look at an example hackingBuddyGPT run. Each run is structured in rounds. At the start of each round, hackingBuddyGPT asks a LLM for the next command to execute (e.g., `whoami`) for the first round. It then executes that command on the virtual machine, prints its output and starts a new round (in which it also includes the output of prior rounds) until it reaches step number 10 or becomes root:
 

--- a/README.md
+++ b/README.md
@@ -173,15 +173,18 @@ $ cp .env.example .env
 $ vi .env
 
 # if you start wintermute without parameters, it will list all available use cases
-$ python wintermute.py
-usage: wintermute.py [-h] {linux_privesc,minimal_linux_privesc,windows privesc} ...
-wintermute.py: error: the following arguments are required: {linux_privesc,windows privesc}
+$ python src/hackingBuddyGPT/cli/wintermute.py
+usage: wintermute.py [-h]
+                     {LinuxPrivesc,WindowsPrivesc,ExPrivEscLinux,ExPrivEscLinuxTemplated,ExPrivEscLinuxHintFile,ExPrivEscLinuxLSE,MinimalWebTesting,WebTestingWithExplanation,SimpleWebAPITesting,SimpleWebAPIDocumentation}
+                     ...
+wintermute.py: error: the following arguments are required: {LinuxPrivesc,WindowsPrivesc,ExPrivEscLinux,ExPrivEscLinuxTemplated,ExPrivEscLinuxHintFile,ExPrivEscLinuxLSE,MinimalWebTesting,WebTestingWithExplanation,SimpleWebAPITesting,SimpleWebAPIDocumentation}
 
 # start wintermute, i.e., attack the configured virtual machine
-$ python wintermute.py minimal_linux_privesc
+$ python src/hackingBuddyGPT/cli/wintermute.py LinuxPrivesc --llm.api_key=sk...ChangeMeToYourOpenAiApiKey --llm.model=gpt-4-turbo --llm.context_size=8192 --conn.host=localhost --conn.username=lowpriv --conn.password=trustno1 --conn.hostname=test1
+
 
 # install dependencies for testing if you want to run the tests
-$ pip install .[testing]
+$ pip install '.[testing]'
 ~~~
 
 ## Publications about hackingBuddyGPT

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ We try to keep our python dependencies as light as possible. This should allow f
 
 To get everything up and running, clone the repo, download requirements, setup API keys and credentials, and start `wintermute.py`:
 
-~~~ bash
+```bash
 # clone the repository
 $ git clone https://github.com/ipa-lab/hackingBuddyGPT.git
 $ cd hackingBuddyGPT
@@ -178,14 +178,36 @@ usage: wintermute.py [-h]
                      {LinuxPrivesc,WindowsPrivesc,ExPrivEscLinux,ExPrivEscLinuxTemplated,ExPrivEscLinuxHintFile,ExPrivEscLinuxLSE,MinimalWebTesting,WebTestingWithExplanation,SimpleWebAPITesting,SimpleWebAPIDocumentation}
                      ...
 wintermute.py: error: the following arguments are required: {LinuxPrivesc,WindowsPrivesc,ExPrivEscLinux,ExPrivEscLinuxTemplated,ExPrivEscLinuxHintFile,ExPrivEscLinuxLSE,MinimalWebTesting,WebTestingWithExplanation,SimpleWebAPITesting,SimpleWebAPIDocumentation}
+```
 
+## Provide a Target Machine over SSH
+
+The next important part is having a machine that we can run our agent against. In our case, the target machine will be situated at `192.168.122.151`.
+
+We are using vulnerable Linux systems running in Virtual Machines for this. Never run this against real systems.
+
+{% callout title="We also provide vulnerable machines!" %}
+We are using virtual machines from our [Linux Privilege-Escalation Benchmark](https://github.com/ipa-lab/benchmark-privesc-linux) project. Feel free to use them for your own research!
+{% /callout %}
+
+## Run the Hacking Agent
+
+Finally we can run hackingBuddyGPT against our provided test VM. Enjoy!
+
+{% callout type="warning" title="Don't be evil!" %}
+Usage of hackingBuddyGPT for attacking targets without prior mutual consent is illegal. It's the end user's responsibility to obey all applicable local, state and federal laws. Developers assume no liability and are not responsible for any misuse or damage caused by this program. Only use for educational purposes.
+{% /callout %}
+
+With that out of the way, let's look at an example hackingBuddyGPT run. Each run is structured in rounds. At the start of each round, hackingBuddyGPT asks a LLM for the next command to execute (e.g., `whoami`) for the first round. It then executes that command on the virtual machine, prints its output and starts a new round (in which it also includes the output of prior rounds) until it reaches step number 10 or becomes root:
+
+```bash
 # start wintermute, i.e., attack the configured virtual machine
-$ python src/hackingBuddyGPT/cli/wintermute.py LinuxPrivesc --llm.api_key=sk...ChangeMeToYourOpenAiApiKey --llm.model=gpt-4-turbo --llm.context_size=8192 --conn.host=localhost --conn.username=lowpriv --conn.password=trustno1 --conn.hostname=test1
+$ python src/hackingBuddyGPT/cli/wintermute.py LinuxPrivesc --llm.api_key=sk...ChangeMeToYourOpenAiApiKey --llm.model=gpt-4-turbo --llm.context_size=8192 --conn.host=192.168.122.151 --conn.username=lowpriv --conn.password=trustno1 --conn.hostname=test1
 
 
 # install dependencies for testing if you want to run the tests
 $ pip install '.[testing]'
-~~~
+```
 
 ## Publications about hackingBuddyGPT
 


### PR DESCRIPTION
Key changes:
1. Script location: src/hackingBuddyGPT/cli/wintermute.py
2. Command argument update: 'minimal_linux_privesc' to 'LinuxPrivesc'
3. API key usage: sk...ChangeMeToYourOpenAiApiKey
4. Package installation: Use quotes - pip install '.[testing]'
5. docs: target VM, not localhost, for safety
* Use `192.168.122.151`
* Add sections to match https://github.com/ipa-lab/docs.hackingbuddy/blob/master/src/app/docs/introduction/installation/page.md
  * Provide a Target Machine over SSH
  * Run the Hacking Agent

Errors fixed:
* File not found
* Invalid argument choice
* Zsh globbing issue with pip install

Co-authored-by: Haley Lifrieri <haleylifrieri@college.harvard.edu>
Co-authored-by: Haley Lifrieri <halifrieri@gmail.com>
Co-authored-by: Muturi David <muturidavid854@gmail.com>
Co-authored-by: Pardaz Banu Mohammad <pardaz.banu786@gmail.com>
Co-authored-by: Pardaz Banu Mohammad <pardazbanu1999@gmail.com>
Co-authored-by: Toluwalope Olateru-Olagbeg <wole2003@gmail.com>