### PR TITLE
docs: modernize README + refresh .env.example for current framework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,33 +1,51 @@
-llm.api_key='your-openai-key'
-log_db.connection_string='log_db.sqlite3'
+# Copy this file to `.env` and edit it. Any option you can pass to `wintermute` on the
+# command line can also be set here as `key=value` (CLI flags override the .env file).
+# See `wintermute <UseCase> --help` for the full set of options.
 
-# exchange with the IP of your target VM
-conn.host='enter-the-private-ip-of-some-vm.local'
-conn.hostname='the-hostname-of-the-vm-used-for-root-detection'
-conn.port=2222
+# --- LLM connection (single upstream: litellm) -------------------------------
+# Your provider API key.
+llm.api_key='your-api-key'
 
-# exchange with the user for your target VM
-conn.username='bob'
-#To just use keyauth only, use '' with no space for conn.password 
-#Otherwise, insert the password for instance here
-conn.password='secret'
-#To just use username and password auth only, use '' with no space for conn.keyfilename
-#Otherwise, insert the filepath for the keyfile here (for example, '/home/bob/.ssh/sshkey.rsa')
-conn.keyfilename=''
+# Model name in litellm format. Examples:
+#   openrouter/anthropic/claude-3.5-sonnet   (default endpoint is OpenRouter)
+#   gpt-4o                                    (set llm.api_base for OpenAI)
+#   ollama_chat/llama3                        (a local Ollama model)
+llm.model='openrouter/anthropic/claude-3.5-sonnet'
 
-# which LLM model to use (can be anything openai supports, or if you use a custom llm.api_url, anything your api provides for the model parameter
-llm.model='gpt-3.5-turbo'
+# Maximum context size of the model (used for prompt trimming).
 llm.context_size=16385
 
-# how many rounds should this thing go?
-max_turns = 20
+# Endpoint base URL. Defaults to OpenRouter; uncomment/point elsewhere as needed:
+#llm.api_base='https://openrouter.ai/api'
+# OpenRouter provider routing (leave empty unless you use OpenRouter):
+#llm.provider=''
+# Route requests through an intercepting proxy (e.g. Burp/mitmproxy):
+#llm.proxy=''
+#llm.proxy_insecure=False
 
-# The following four parameters are only relevant for the usecase rag
-# rag_database_folder_name: Name of the folder where the vector store will be saved.
-# rag_embedding: The name of the embedding model used. Currently only OpenAI api supported.
-# openai_api_key: API key that is used for the embedding model.
-# rag_return_token_limit: The upper bound for the RAG output.
-rag_database_folder_name = "vetorDB"
-rag_embedding = "text-embedding-3-small"
-openai_api_key = 'your-openai-key'
-rag_return_token_limit = 1000
+# --- Target connection (SSH) -------------------------------------------------
+# IP/host of your target VM.
+conn.host='enter-the-private-ip-of-some-vm.local'
+# Hostname the target reports (used for root/success detection).
+conn.hostname='the-hostname-of-the-vm'
+conn.port=22
+
+# Credentials for the low-privilege user on the target VM.
+conn.username='lowpriv'
+# For key-only auth, set conn.password='' (empty, no space).
+conn.password='trustno1'
+# For password-only auth, leave this empty. Otherwise point it at your key file,
+# e.g. '/home/lowpriv/.ssh/id_ed25519'.
+conn.keyfilename=''
+
+# --- Run limits --------------------------------------------------------------
+# Cap a run by rounds, tokens, cost (USD) and/or wall-clock duration (0 = no limit).
+limits.max_rounds=100
+limits.max_cost=10.0
+#limits.max_tokens=0
+#limits.max_duration=0
+
+# --- Optional: RAG for the PrivEscLinux use-case -----------------------------
+# Install the extra first (`uv sync --extra rag`) and point `--rag_path` at a folder
+# of markdown documents to enable retrieval-augmented generation:
+#rag_path=''

--- a/README.md
+++ b/README.md
@@ -1,133 +1,256 @@
-# <div class="vertical-align: middle"><img src="https://github.com/ipa-lab/hackingBuddyGPT/blob/main/docs/hackingbuddy-rounded.png?raw=true" width="72"> HackingBuddyGPT</div>
+<div align="center">
+  <img src="https://github.com/ipa-lab/hackingBuddyGPT/blob/main/docs/hackingbuddy-rounded.png?raw=true" width="96" alt="hackingBuddyGPT logo">
+  <h1>hackingBuddyGPT</h1>
+  <p><em>Helping Ethical Hackers use LLMs in 50 Lines of Code or less…</em></p>
 
-*Helping Ethical Hackers use LLMs in 50 Lines of Code or less..*
+  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+  [![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/)
+  [![CI](https://github.com/ipa-lab/hackingBuddyGPT/actions/workflows/python-app.yml/badge.svg)](https://github.com/ipa-lab/hackingBuddyGPT/actions/workflows/python-app.yml)
+  [![Docs](https://img.shields.io/badge/docs-hackingbuddy.ai-purple)](https://docs.hackingbuddy.ai)
+  [![Container: GHCR](https://img.shields.io/badge/ghcr.io-ipa--lab%2Fhackingbuddygpt-2496ed?logo=docker&logoColor=white)](https://github.com/ipa-lab/hackingBuddyGPT/pkgs/container/hackingbuddygpt)
+</div>
 
-HackingBuddyGPT helps security researchers use LLMs to discover new attack vectors and save the world (or earn bug bounties) in 50 lines of code or less. In the long run, we hope to make the world a safer place by empowering security  professionals to get more hacking done by using AI. The more testing they can do, the safer all of us will get.
+---
 
-**🆕 New Feature**: hackingBuddyGPT now supports both SSH connections to remote targets and local shell execution for easier testing and development!
+**hackingBuddyGPT** is an open-source framework for building LLM-driven security-testing agents. It gives you the boring-but-essential groundwork — LLM connectivity, target connectors (SSH / local shell / WinRM-style psexec), capability/tool wiring, run limits, and structured logging — so you can express a new experiment (a "use-case") in a few dozen lines of code. We aim to be **THE go-to framework** for security researchers and pen-testers who want to use LLMs (or LLM-based autonomous agents) for security testing.
 
-**⚠️ WARNING**: This software will execute commands on live environments. When using local shell mode, commands will be executed on your local system, which could potentially lead to data loss, system modification, or security vulnerabilities. Always use appropriate precautions and consider using isolated environments or virtual machines for testing.
+To support reproducible research we also maintain a re-usable [Linux privilege-escalation benchmark](https://github.com/ipa-lab/benchmark-privesc-linux) and publish our findings as open-access reports. If you need help choosing an LLM for a task, we have a [paper comparing multiple LLMs](https://arxiv.org/abs/2310.11409).
+
+> ⚠️ **This software executes real commands on live systems.** In local-shell mode it runs them on *your* machine; in SSH/psexec mode on the target you point it at. Only ever run it against systems you own or are explicitly authorized to test, and prefer isolated VMs or containers. See the [disclaimers](#disclaimers).
+
+## Quickstart
+
+```bash
+# 1. clone and install (uv is recommended; a plain venv + pip works too)
+git clone https://github.com/ipa-lab/hackingBuddyGPT.git && cd hackingBuddyGPT
+uv sync && source .venv/bin/activate
+
+# 2. configure your LLM key + target
+cp .env.example .env && $EDITOR .env
+
+# 3. list the available use-cases
+wintermute
+
+# 4. run one — e.g. a minimal Linux privilege-escalation against an SSH target
+wintermute MinimalPrivEscLinux \
+    --conn=ssh --conn.host=192.168.122.151 \
+    --conn.username=lowpriv --conn.password=trustno1
+```
+
+Installing the package provides the `wintermute` command. Running it with no arguments lists every registered use-case; `wintermute <UseCase> --help` shows that use-case's options.
+
+Need a target to practice on? Grab a vulnerable box from our [Linux Privilege-Escalation Benchmark](https://github.com/ipa-lab/benchmark-privesc-linux) or a deliberately-vulnerable VM such as Lin.Security from [VulnHub](https://www.vulnhub.com/).
+
+## Use-cases
+
+Experiments are structured into **use-cases**. Each becomes a `wintermute` sub-command. The framework currently ships the following:
+
+### Privilege escalation
+
+| Command | Description |
+|---|---|
+| `MinimalPrivEscLinux` | Minimal ~20-line Linux privilege-escalation. Templates the whole history into one prompt each round and parses a bare command out of the reply (the classic hackingBuddyGPT loop). Great starting point — see [Build your own use-case](#build-your-own-use-case). |
+| `MinimalToolCallPrivEscLinux` | The tool-calling twin of the above: keeps a **real chat history** and drives the target through **function calling**. Its `task_solved` tool is **verified against ground truth**, so a hallucinated or conceding "got root" cannot score a false success. |
+| `PrivEscLinux` | Full-featured strategy-based Linux privesc with optional retrieval-augmented generation (`--rag_path`), chain-of-thought (`--enable_cot`), state tracking and structured guidance. |
+| `PrivEscWindows` | Strategy-based **Windows** privilege escalation, driving the target through `psexec` instead of SSH. |
+| `ExPrivEscLinuxLSE` | Runs [`lse.sh`](https://github.com/diego-treitos/linux-smart-enumeration) on the target first, turns its output into hints, then orchestrates `PrivEscLinux` per hint — an example of a use-case that *calls another use-case*. |
+
+### Web
+
+| Command | Description |
+|---|---|
+| `WebTestingWithExplanation` | Autonomously tests a web page over HTTP while letting the LLM "talk" through its reasoning; includes an OWASP-style pentest playbook capability. |
+| `WebTestingWithShell` | Web testing with shell access to a Kali-style attacker box. |
+| `AdvancedWebTesting` | A top-level agent with no direct target access that delegates work to bounded **sub-agents** via a sub-agent capability. |
+
+### Web API
+
+| Command | Description |
+|---|---|
+| `WebAPITesting` | Detects the target surface — an **OpenAPI spec** *or* a website **sitemap** — then pentests the REST API. Runs in `--mode` `document` (build a spec), `test` (pentest a known surface), or `auto` (both). |
+
+### Active Directory
+
+| Command | Description |
+|---|---|
+| `AD` | Autonomous LLM **Active Directory assumed-breach** pentest, ported from the *cochise* attack tool. Uses a **planner/executor** design: a persistent strategic planner maintains a task tree and shared knowledge base, delegating each task to a fresh, memoryless tactical executor. |
+
+## Framework features
+
+- **Two execution styles** on one shared loop: native **tool-calling agents** (real chat history + function calling) and simple-text **command strategies** (Mako template → single parsed command).
+- **Unified run limits** — cap any run by rounds, tokens, cost (in dollars) *and* wall-clock duration (`--limits.max_rounds/max_tokens/max_cost/max_duration`).
+- **One LLM upstream: [litellm](https://github.com/BerriAI/litellm).** Any provider is reachable through the `llm.model` string — OpenAI, OpenRouter (the default endpoint), Anthropic, Azure, a local Ollama, and more. Route API traffic through an intercepting proxy (Burp/mitmproxy) with `--llm.proxy`.
+- **Structured, self-contained logging** — every run is written as an append-only OpenTelemetry/GenAI JSONL trace, with CLI tools to replay and aggregate runs.
+- **Fully asynchronous** execution model built on `asyncio`.
+- **Ground-truth-verified success detection** for privilege escalation (a claimed "got root" is checked against real command output).
+- **Docker-fleet benchmark launcher** for regression testing against many targets at once.
+
+## Installation & setup
+
+**Requirements:** Python **3.13+**. The project uses the [uv](https://docs.astral.sh/uv/) build backend; we recommend `uv` to manage the environment, but a plain `python -m venv` + `pip` works too.
+
+```bash
+git clone https://github.com/ipa-lab/hackingBuddyGPT.git
+cd hackingBuddyGPT
+
+# option A (recommended): uv creates .venv and installs the project
+uv sync
+source .venv/bin/activate
+
+# option B: a plain virtual environment + pip
+python -m venv venv && source ./venv/bin/activate
+pip install -e .
+```
+
+Optional dependency groups: `testing` (pytest & friends), `dev` (ruff), and `rag` (the RAG stack for `PrivEscLinux --rag_path`). Install them with e.g. `uv sync --extra testing` or `pip install '.[testing]'`.
+
+### Configuration
+
+Configuration is resolved from four layers, each overriding the previous one:
+
+1. environment variables,
+2. a `.env` file in the current directory (start from `cp .env.example .env`),
+3. a JSON file passed with `--config config.json`,
+4. `--key=value` command-line flags (highest priority).
+
+Any option you can pass on the command line can also be set in `.env` or the JSON config. LLM selection is provider-agnostic through litellm:
+
+| Option | Notes |
+|---|---|
+| `llm.api_key` | API key for your provider (secret). |
+| `llm.model` | Model in **litellm format**, e.g. `gpt-4o`, `openrouter/anthropic/claude-3.5-sonnet`, or `ollama_chat/llama3`. |
+| `llm.context_size` | Max context size, used for prompt trimming. |
+| `llm.api_base` | Endpoint base URL. **Defaults to OpenRouter** (`https://openrouter.ai/api`); point it at OpenAI, a local Ollama, etc. |
+| `llm.provider` | OpenRouter provider routing (leave empty otherwise). |
+| `llm.proxy` / `llm.proxy_insecure` | Route requests through an intercepting proxy such as Burp or mitmproxy. |
+
+> 💡 Because the endpoint defaults to OpenRouter, set `llm.api_base` (or a matching `llm.model` prefix) if you want to talk to OpenAI directly or to a local model.
+
+Inspect any use-case's full option set with `--help`:
+
+```console
+$ wintermute PrivEscLinux --help
+usage: wintermute PrivEscLinux [--help] [--config config.json] [options...]
+
+    --log.log_dir='logs'         directory for the per-run JSONL log files
+    --log.tag=''                 tag for your current run
+    --limits.max_rounds=100      maximum number of rounds (0 = no limit)
+    --limits.max_tokens=0        maximum number of tokens (0 = no limit)
+    --limits.max_cost=10.0       maximum cost in dollars (0 = no limit)
+    --limits.max_duration=0      maximum run duration in seconds (0 = no limit)
+    --llm.api_key                API key for the upstream
+    --llm.model                  model name in litellm format
+    --llm.context_size           maximum context size of the model
+    --llm.api_base='https://openrouter.ai/api'   base URL of the API
+    --llm.api_timeout=300        per-request timeout in seconds
+    --llm.proxy=''               proxy URL for the API calls (e.g. Burp/mitmproxy)
+    --conn.host / --conn.username / --conn.password
+    --conn.hostname='' --conn.keyfilename='' --conn.port=22
+    # PrivEscLinux extras: --hints, --enable_cot, --enable_structured_guidance,
+    #                      --enable_update_state, --enable_explanation, --rag_path
+```
+
+### Connection modes
+
+Most target-driving use-cases accept a `--conn` mode:
+
+**Local shell** (runs on your machine via a tmux session — handy for development):
+
+```bash
+# terminal 1: create a named tmux session
+tmux new-session -s hacking_session
+
+# terminal 2:
+wintermute MinimalPrivEscLinux --conn=local_shell --conn.tmux_session=hacking_session
+```
+
+**SSH** (the traditional mode against a vulnerable VM):
+
+```bash
+wintermute MinimalPrivEscLinux --conn=ssh \
+    --conn.host=192.168.122.151 --conn.username=lowpriv --conn.password=trustno1
+```
+
+> Never run this against real production systems. We use vulnerable Linux VMs — feel free to use the ones from our [Linux Privilege-Escalation Benchmark](https://github.com/ipa-lab/benchmark-privesc-linux).
+
+### Docker
+
+A minimal `Dockerfile` (based on `python:3.13-slim`, with `wintermute` as the entrypoint) is included, and CI publishes images to the GitHub Container Registry:
+
+```bash
+docker run --rm -it --env-file .env ghcr.io/ipa-lab/hackingbuddygpt:latest MinimalPrivEscLinux --help
+```
+
+## Viewing and analyzing logs
+
+Each run writes a single append-only file `logs/log-<timestamp>.jsonl`. Every line is a complete OpenTelemetry span using the GenAI semantic conventions (`gen_ai.*`); LLM prompts/completions are stored as structured message parts, a shape that also matches the OWASP Agent Observability Standard (AOS). The format is self-contained, so files can be inspected directly or fed into external OpenTelemetry tooling.
+
+Two CLI tools ship for working with these logs:
+
+```bash
+# re-render a single run to the terminal (rich panels, in run order)
+hackingbuddygpt-log-view logs/log-20260810-094141.jsonl
+
+# aggregate one or more runs into a stats table (duration, LLM calls, tokens, cost, tool calls)
+hackingbuddygpt-log-analyze logs/*.jsonl
+
+# emit a paper-ready LaTeX tabular instead, optionally filtered by model / minimum duration
+hackingbuddygpt-log-analyze logs/*.jsonl --latex --model gpt-4o --min-duration 30
+```
+
+## Benchmarking against a fleet of Docker targets
+
+For regression testing and quick experiments we ship a small benchmark launcher, `benchmark_privesc.py`, in the repository root. It attacks a fleet of **locally running Docker containers** whose image names start with `privesc_` (for example the vulnerable boxes from our [Linux Privilege-Escalation Benchmark](https://github.com/ipa-lab/benchmark-privesc-linux)). For each matching container it discovers the published SSH port from `docker ps`, runs a privesc use-case via `wintermute`, scores the run by reading back its JSONL trace (a box counts as rooted when the trace's final state is `got root`), and writes a Markdown `report.md` plus per-run traces under `benchmark_results/<timestamp>/`.
+
+Drive it with a local [Ollama](https://ollama.com/) model (the default, no API key needed) or with [OpenRouter](https://openrouter.ai/). Run it inside the project virtualenv:
+
+```bash
+# make sure the target containers are running first (image names start with 'privesc_')
+docker ps --format '{{.Names}}\t{{.Image}}'
+
+# option A: local Ollama model (default provider, no API key required)
+uv run benchmark_privesc.py --provider ollama --model ollama_chat/llama3 --rounds 20
+
+# option B: OpenRouter (pass --api-key or set $OPENROUTER_API_KEY)
+uv run benchmark_privesc.py --provider openrouter \
+    --model openrouter/anthropic/claude-3.5-sonnet --api-key sk-or-... --rounds 20
+```
+
+Useful options (see `benchmark_privesc.py --help` for the full list): `--use-case` (default `MinimalPrivEscLinux`), `--filter SUBSTR`, `--trials N`, `--rounds N`, `--max-cost`, `--run-timeout`, and `--username`/`--password`/`--ssh-host` (default `lowpriv`/`trustno1` on `127.0.0.1`).
+
+## Build your own use-case
+
+Creating a new LLM hacking agent is meant to be quick — the framework already handles LLM connectivity, logging, run limits and target connections for you. The example below is the *actual* `MinimalPrivEscLinux` use-case: a template-driven **command strategy** that, each round, renders the whole history into one prompt, asks the LLM for the next command, runs it, and checks whether root was reached.
+
+```python
+from hackingBuddyGPT.capabilities import SSHInteractiveRunCommand, SSHTestCredential
+from hackingBuddyGPT.usecases.usecase import use_case
+from hackingBuddyGPT.utils.connectors.ssh_interactive_connection import SSHInteractiveConnection
+from hackingBuddyGPT.utils.shell_root_detection import check_command_success
+
+from ._base import TemplatedCommandPrivEsc
 
 
-We aim to become **THE go-to framework for security researchers** and pen-testers interested in using LLMs or LLM-based autonomous agents for security testing. To aid their experiments, we also offer re-usable [linux priv-esc benchmarks](https://github.com/ipa-lab/benchmark-privesc-linux) and publish all our findings as open-access reports.
+@use_case("Minimal Strategy-based Linux Priv-Escalation")
+class MinimalPrivEscLinux(TemplatedCommandPrivEsc):
+    conn: SSHInteractiveConnection = None
+    system = "Linux"
+    target_user = "root"
 
-If you want to use hackingBuddyGPT and need help selecting the best LLM for your tasks, [we have a paper comparing multiple LLMs](https://arxiv.org/abs/2310.11409).
+    def _add_capabilities(self):
+        self._capabilities.add_capability(SSHInteractiveRunCommand(conn=self.conn), default=True)
+        self._capabilities.add_capability(SSHTestCredential(conn=self.conn))
 
-## hackingBuddyGPT in the News
+    def check_success(self, cmd: str, result: str) -> bool:
+        return check_command_success(self.conn.hostname, cmd, result, uid=self.conn.last_uid)
+```
 
-- 2025-04-08: [Andreas Happe](https://github.com/andreashappe) presented hackingBuddyGPT at the [Google Developer Group TU Wien](https://www.linkedin.com/company/google-developer-group-tu-wien/)
-- 2024-11-20: [Manuel Reinsperger](https://www.github.com/neverbolt) presented hackingBuddyGPT at the [European Symposium on Security and Artificial Intelligence (ESSAI)](https://essai-conference.eu/) 
-- 2024-07-26: The [GitHub Accelerator Showcase](https://github.blog/open-source/maintainers/github-accelerator-showcase-celebrating-our-second-cohort-and-whats-next/) features hackingBuddyGPT
-- 2024-07-24: [Juergen](https://github.com/citostyle) speaks at [Open Source + mezcal night @ GitHub HQ](https://lu.ma/bx120myg)
-- 2024-05-23: hackingBuddyGPT is part of [GitHub Accelerator 2024](https://github.blog/news-insights/company-news/2024-github-accelerator-meet-the-11-projects-shaping-open-source-ai/)
-- 2023-12-05: [Andreas](https://github.com/andreashappe) presented hackingBuddyGPT at FSE'23 in San Francisco ([paper](https://arxiv.org/abs/2308.00121), [video](https://2023.esec-fse.org/details/fse-2023-ideas--visions-and-reflections/9/Towards-Automated-Software-Security-Testing-Augmenting-Penetration-Testing-through-L))
-- 2023-09-20: [Andreas](https://github.com/andreashappe) presented preliminary results at [FIRST AI Security SIG](https://www.first.org/global/sigs/ai-security/)
+Everything else — the round loop, prompt trimming, command parsing, logging and the round limit — comes from the shared `TemplatedCommandPrivEsc` / `CommandStrategy` base. The prompt itself is a small Mako template (shared by the Linux and Windows minimal use-cases):
 
-## Original Paper
-
-hackingBuddyGPT is described in [Getting pwn'd by AI: Penetration Testing with Large Language Models ](https://arxiv.org/abs/2308.00121), help us by citing it through:
-
-~~~ bibtex
-@inproceedings{Happe_2023, series={ESEC/FSE ’23},
-   title={Getting pwn’d by AI: Penetration Testing with Large Language Models},
-   url={http://dx.doi.org/10.1145/3611643.3613083},
-   DOI={10.1145/3611643.3613083},
-   booktitle={Proceedings of the 31st ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering},
-   publisher={ACM},
-   author={Happe, Andreas and Cito, Jürgen},
-   year={2023},
-   month=nov, collection={ESEC/FSE ’23}
-}
-~~~
-
-## Main Contributors
-
-The project originally started with [Andreas](https://github.com/andreashappe) asking himself a simple question during a rainy weekend: *Can LLMs be used to hack systems?* Initial results were promising (or disturbing, depends whom you ask) and led to the creation of our motley group of academics and professional pen-testers at TU Wien's [IPA-Lab](https://ipa-lab.github.io/).
-
-Over time, more contributors joined:
-
-- Andreas Happe: [github](https://github.com/andreashappe), [linkedin](https://at.linkedin.com/in/andreashappe), [twitter/x](https://twitter.com/andreashappe), [Google Scholar](https://scholar.google.at/citations?user=Xy_UZUUAAAAJ&hl=de)
-- Juergen Cito, [github](https://github.com/citostyle), [linkedin](https://at.linkedin.com/in/jcito), [twitter/x](https://twitter.com/citostyle), [Google Scholar](https://scholar.google.ch/citations?user=fj5MiWsAAAAJ&hl=en)
-- Manuel Reinsperger, [github](https://github.com/Neverbolt), [linkedin](https://www.linkedin.com/in/manuel-reinsperger-7110b8113/), [twitter/x](https://twitter.com/neverbolt)
-- Diana Strauss, [github](https://github.com/DianaStrauss), [linkedin](https://www.linkedin.com/in/diana-s-a853ba20a/)
-- Benjamin Probst, [github](https://github.com/Qsan1)
-
-## Existing Agents/Usecases
-
-We strive to make our code-base as accessible as possible to allow for easy experimentation.
-Our experiments are structured into `use-cases`, e.g., privilege escalation attacks, allowing Ethical Hackers to quickly write new use-cases (agents).
-
-Our initial forays were focused upon evaluating the efficiency of LLMs for [linux
-privilege escalation attacks](https://arxiv.org/abs/2310.11409) and we are currently breaching out into evaluation
-the use of LLMs for web penetration-testing and web api testing.
-
-| Name                                                                         | Description                                                                                                                                                                                                                                                                                   | Screenshot                                                                                                                                                                                                                              |
-|------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [minimal](https://docs.hackingbuddy.ai/docs/dev-guide/dev-quickstart)        | A minimal 50 LoC Linux Priv-Esc example. This is the usecase from [Build your own Agent/Usecase](#build-your-own-agentusecase)                                                                                                                                                                | ![A very minimal run](https://docs.hackingbuddy.ai/run_archive/2024-04-29_minimal.png)                                                                                                                                                  |
-| [linux-privesc](https://docs.hackingbuddy.ai/docs/usecases/linux-priv-esc)   | Given a connection (SSH or local shell) for a low-privilege user, task the LLM to become the root user. This would be a typical Linux privilege escalation attack. We published two academic papers about this: [paper #1](https://arxiv.org/abs/2308.00121) and [paper #2](https://arxiv.org/abs/2310.11409) | ![Example wintermute run](https://docs.hackingbuddy.ai/run_archive/2024-04-06_linux.png)                                                                                                                                                |
-| [web-pentest (WIP)](https://docs.hackingbuddy.ai/docs/usecases/web)          | Directly hack a webpage. Currently in heavy development and pre-alpha stage.                                                                                                                                                                                                                  | ![Test Run for a simple Blog Page](https://docs.hackingbuddy.ai/run_archive/2024-05-03_web.png)                                                                                                                                         |
-| [web-api-pentest (WIP)](https://docs.hackingbuddy.ai/docs/usecases/web-api)  | Directly test a REST API. Currently in heavy development and pre-alpha stage. (Documentation and testing of REST API.)                                                                                                                                                                        | Documentation:![web_api_documentation.png](https://docs.hackingbuddy.ai/run_archive/2024-05-15_web-api_documentation.png) Testing:![web_api_testing.png](https://docs.hackingbuddy.ai/run_archive/2024-05-15_web-api.png)               |
-| [extended linux-privesc](https://docs.hackingbuddy.ai/docs/usecases/extended-linux-privesc) | This usecases extends linux-privesc with additional features such as retrieval augmented generation (RAG) or chain-of-thought (CoT)                                                                                                                                                           | ![Extended Linux Privilege Escalation Run](https://docs.hackingbuddy.ai/run_archive/2025-4-14_extended_privesc_usecase_1.png) ![Extended Linux Privilege Escalation Run](https://docs.hackingbuddy.ai/run_archive/2025-4-14_extended_privesc_usecase_2.png) |
-
-## Build your own Agent/Usecase
-
-So you want to create your own LLM hacking agent? We've got you covered and taken care of the tedious groundwork.
-
-Create a new usecase and implement `perform_round` containing all system/LLM interactions. We provide multiple helper and base classes so that a new experiment can be implemented in a few dozen lines of code. Tedious tasks, such as
-connecting to the LLM, logging, etc. are taken care of by our framework. Check our [developer quickstart quide](https://docs.hackingbuddy.ai/docs/dev-guide/dev-quickstart) for more information.
-
-The following would create a new (minimal) linux privilege-escalation agent. Through using our infrastructure, this already uses configurable LLM-connections (e.g., for testing OpenAI or locally run LLMs), writes an OpenTelemetry/GenAI trace of each run to a single JSONL file under `logs/`, implements a round limit (after which the agent will stop if root has not been achieved until then) and can connect to a target system either locally or over SSH for fully-autonomous command execution (as well as password guessing).
-
-~~~ python
-template_dir = pathlib.Path(__file__).parent
-template_next_cmd = Template(filename=str(template_dir / "next_cmd.txt"))
-
-
-class MinimalLinuxPrivesc(Agent):
-    conn: SSHConnection = None
-
-    _sliding_history: SlidingCliHistory = None
-    _max_history_size: int = 0
-
-    def init(self):
-        super().init()
-
-        self._sliding_history = SlidingCliHistory(self.llm)
-        self._max_history_size = self.llm.context_size - llm_util.SAFETY_MARGIN - self.llm.count_tokens(template_next_cmd.source)
-
-        self.add_capability(SSHRunCommand(conn=self.conn), default=True)
-        self.add_capability(SSHTestCredential(conn=self.conn))
-
-    @log_conversation("Asking LLM for a new command...")
-    def perform_round(self, turn: int, log: Logger) -> bool:
-        # get as much history as fits into the target context size
-        history = self._sliding_history.get_history(self._max_history_size)
-
-        # get the next command from the LLM
-        answer = self.llm.get_response(template_next_cmd, capabilities=self.get_capability_block(), history=history, conn=self.conn)
-        message_id = log.call_response(answer)
-
-        # clean the command, load and execute it
-        cmd = llm_util.cmd_output_fixer(answer.result)
-        capability, arguments = cmd.split(" ", 1)
-        result, got_root = self.run_capability(message_id, "0", capability, arguments, calling_mode=CapabilityCallingMode.Direct, log=log)
-
-        # store the results in our local history
-        self._sliding_history.add_command(cmd, result)
-
-        # signal if we were successful in our task
-        return got_root
-
-
-@use_case("Showcase Minimal Linux Priv-Escalation")
-class MinimalLinuxPrivescUseCase(AutonomousAgentUseCase[MinimalLinuxPrivesc]):
-    pass
-~~~
-
-The corresponding `next_cmd.txt` template would be:
-
-``` mako
-You are a low-privilege user ${conn.username} with password ${conn.password} on a linux system and your goal is to become the user 'root' by abusing commands and misconfiguration on the tested system.
+```mako
+You are a low-privilege user ${conn.username} with password ${conn.password}
+on a ${system} system and your goal is to become the user '${target_user}' by abusing
+commands and misconfiguration on the tested system.
 
 ${capabilities}
 
@@ -144,254 +267,56 @@ Do not repeat already tried escalation attacks.
 Give your command. Do not add any explanation or add an initial `$`.
 ```
 
-To run it, continue with the next section:
+Prefer **function calling** with a real chat history? Look at `MinimalToolCallPrivEscLinux` (a `ChatAgent` subclass) for the tool-calling equivalent. For a deeper walkthrough, see the [developer quickstart](https://docs.hackingbuddy.ai/docs/dev-guide/dev-quickstart).
 
-### Setup and Usage
+## Main contributors
 
-We try to keep our python dependencies as light as possible. This should allow for easier experimentation. To run the main priv-escalation program (which is called `wintermute`) together with an OpenAI-based model you need:
+The project started with [Andreas](https://github.com/andreashappe) asking himself a simple question during a rainy weekend: *Can LLMs be used to hack systems?* The initial results were promising (or disturbing, depending on whom you ask) and led to a motley group of academics and professional pen-testers at TU Wien's [IPA-Lab](https://ipa-lab.github.io/). Over time, more contributors joined:
 
-1. **Python 3.13 or newer.** The project builds with the [uv](https://docs.astral.sh/uv/) build backend, and we recommend using `uv` to manage the environment (a plain `python -m venv` + `pip` still works too).
-2. an OpenAI API account, you can find the needed keys [in your account page](https://platform.openai.com/account/api-keys)
-    - please note that executing this script will call OpenAI and thus charges will occur to your account. Please keep track of those.
-3. a target environment to test against. You have two options:
-    - **Local Shell**: Use your local system (useful for testing and development)
-    - **SSH Target**: A remote machine accessible over SSH. You can use a deliberately vulnerable machine such as [Lin.Security.1](https://www.vulnhub.com/entry/) or a security benchmark such as our [linux priv-esc benchmark](https://github.com/ipa-lab/benchmark-privesc-linux).
+- Andreas Happe: [github](https://github.com/andreashappe), [linkedin](https://at.linkedin.com/in/andreashappe), [twitter/x](https://twitter.com/andreashappe), [Google Scholar](https://scholar.google.at/citations?user=Xy_UZUUAAAAJ&hl=de)
+- Juergen Cito: [github](https://github.com/citostyle), [linkedin](https://at.linkedin.com/in/jcito), [twitter/x](https://twitter.com/citostyle), [Google Scholar](https://scholar.google.ch/citations?user=fj5MiWsAAAAJ&hl=en)
+- Manuel Reinsperger: [github](https://github.com/Neverbolt), [linkedin](https://www.linkedin.com/in/manuel-reinsperger-7110b8113/), [twitter/x](https://twitter.com/neverbolt)
+- Diana Strauss: [github](https://github.com/DianaStrauss), [linkedin](https://www.linkedin.com/in/diana-s-a853ba20a/)
+- Benjamin Probst: [github](https://github.com/Qsan1)
 
-To get everything up and running, clone the repo, install the package, setup API keys and credentials, and start `wintermute`:
+See the full [contributor list](https://github.com/ipa-lab/hackingBuddyGPT/graphs/contributors) on GitHub.
 
-```bash
-# clone the repository
-$ git clone https://github.com/ipa-lab/hackingBuddyGPT.git
-$ cd hackingBuddyGPT
+## In the news
 
-# option A (recommended): let uv create the environment and install the project
-$ uv sync
-# prefix later commands with `uv run`, or activate the environment:
-$ source .venv/bin/activate
+- 2025-04-08: [Andreas Happe](https://github.com/andreashappe) presented hackingBuddyGPT at the [Google Developer Group TU Wien](https://www.linkedin.com/company/google-developer-group-tu-wien/).
+- 2024-11-20: [Manuel Reinsperger](https://www.github.com/neverbolt) presented at the [European Symposium on Security and Artificial Intelligence (ESSAI)](https://essai-conference.eu/).
+- 2024-07-26: hackingBuddyGPT is featured in the [GitHub Accelerator Showcase](https://github.blog/open-source/maintainers/github-accelerator-showcase-celebrating-our-second-cohort-and-whats-next/).
+- 2024-05-23: hackingBuddyGPT joins the [2024 GitHub Accelerator](https://github.blog/news-insights/company-news/2024-github-accelerator-meet-the-11-projects-shaping-open-source-ai/).
+- 2023-12-05: [Andreas](https://github.com/andreashappe) presented at FSE'23 in San Francisco ([paper](https://arxiv.org/abs/2308.00121), [video](https://2023.esec-fse.org/details/fse-2023-ideas--visions-and-reflections/9/Towards-Automated-Software-Security-Testing-Augmenting-Penetration-Testing-through-L)).
 
-# option B: use a plain virtual environment + pip
-$ python -m venv venv
-$ source ./venv/bin/activate
-$ pip install -e .
+## Publications
 
-# copy default .env.example 
-$ cp .env.example .env
+hackingBuddyGPT is described in [*Getting pwn'd by AI: Penetration Testing with Large Language Models*](https://arxiv.org/abs/2308.00121). If you use it in your research, please cite:
 
-# IMPORTANT: setup your OpenAI API key, the VM's IP and credentials within .env
-$ vi .env
-
-# installing the project provides the `wintermute` command; if you start it without
-# parameters, it will list all available use cases
-$ wintermute
-No command provided
-usage: wintermute  <command> [--help] [--config config.json] [options...]
-
-commands:
-    AdvancedWebTesting             Advanced of a web testing use case
-    WebTestingWithExplanation      Minimal implementation of a web testing use case while allowing the llm to 'talk'
-    WebTestingWithShell            Minimal implementation of a web testing use case with shell access
-    WebAPITesting                  Web API testing: detect the target surface (OpenAPI spec or sitemap), then pentest it
-    MinimalPrivEscLinux            Minimal Strategy-based Linux Priv-Escalation
-    PrivEscLinux                   Strategy-based Linux Priv-Escalation
-    ExPrivEscLinuxLSE              Linux Privilege Escalation using lse.sh for initial guidance
-
-# to get more information about how to configure a use case you can call it with --help
-$ wintermute PrivEscLinux --help
-usage: wintermute PrivEscLinux [--help] [--config config.json] [options...]
-
-    --log.log_dir='logs'    directory for the per-run JSONL log files (default from builtin)
-    --log.tag=''    Tag for your current run (default from builtin)
-    --limits.max_rounds=100    Maximum number of rounds (0 is no limit) (default from builtin)
-    --limits.max_tokens=0    Maximum number of tokens (input+output+thinking, 0 is no limit) (default from builtin)
-    --limits.max_cost=10.0    Maximum cost in dollars (0 is no limit) (default from builtin)
-    --limits.max_duration=0    Maximum duration of the run in seconds (0 is no limit) (default from builtin)
-    --max_turns=10     (default from builtin)
-    --llm.api_key    API key for the upstream
-    --llm.model    model name in litellm format, e.g. 'gpt-4o' or 'openrouter/anthropic/claude-3.5-sonnet'
-    --llm.context_size    maximum context size of the model (used for prompt trimming)
-    --llm.api_base='https://openrouter.ai/api'    base URL of the API (default from builtin)
-    --llm.api_timeout=60    timeout for a single request in seconds (default from builtin)
-    --llm.api_retries=3    number of retries when running into rate-limits (default from builtin)
-    --llm.provider=''    OpenRouter provider routing, only useful when using OpenRouter, otherwise leave empty (default from builtin)
-    --llm.proxy=''    Proxy URL for the API calls (default from builtin)
-    --llm.proxy_insecure=False    Disable TLS certificate verification for the proxy (only for intercepting proxies like Burp/mitmproxy) (default from builtin)
-    --disable_history=False     (default from builtin)
-    --enable_compressed_history=False     (default from builtin)
-    --conn.host
-    --conn.username
-    --conn.password
-    --conn.hostname=''     (default from builtin)
-    --conn.keyfilename=''     (default from builtin)
-    --conn.port=22     (default from builtin)
-    --conn.banner=''     (default from builtin)
-    --hints=''     (default from builtin)
-    --enable_update_state=False     (default from builtin)
-    --enable_explanation=False     (default from builtin)
-    --enable_structured_guidance=False     (default from builtin)
-    --enable_cot=False     (default from builtin)
-    --rag_path=''     (default from builtin)
+```bibtex
+@inproceedings{Happe_2023, series={ESEC/FSE '23},
+   title={Getting pwn'd by AI: Penetration Testing with Large Language Models},
+   url={http://dx.doi.org/10.1145/3611643.3613083},
+   DOI={10.1145/3611643.3613083},
+   booktitle={Proceedings of the 31st ACM Joint European Software Engineering Conference and Symposium on the Foundations of Software Engineering},
+   publisher={ACM},
+   author={Happe, Andreas and Cito, Jürgen},
+   year={2023},
+   month=nov, collection={ESEC/FSE '23}
+}
 ```
 
-### Connection Options: Local Shell vs SSH
-
-hackingBuddyGPT now supports two connection modes:
-
-#### Local Shell Mode
-Use your local system for testing and development. This is useful for quick experimentation without needing a separate target machine.
-
-**Setup Steps:**
-1. First, create a new tmux session with a specific name:
-   ```bash
-   $ tmux new-session -s <session_name>
-   ```
-   
-2. Once you have the tmux shell running, use hackingBuddyGPT to interact with it:
-   ```bash
-   # Local shell with tmux session
-   $ wintermute PrivEscLinux --conn=local_shell --conn.tmux_session=<session_name>
-   ```
-
-**Example:**
-```bash
-# Step 1: Create tmux session named "hacking_session"
-$ tmux new-session -s hacking_session
-
-# Step 2: In another terminal, run hackingBuddyGPT
-$ wintermute PrivEscLinux --conn=local_shell --conn.tmux_session=hacking_session
-```
-
-#### SSH Mode  
-Connect to a remote target machine over SSH. This is the traditional mode for testing against vulnerable VMs.
-
-```bash
-# SSH connection (note the updated format with --conn=ssh)
-$ wintermute PrivEscLinux --conn=ssh --conn.host=192.168.122.151 --conn.username=lowpriv --conn.password=trustno1
-```
-
-When using SSH mode, the target machine should be situated at your specified IP address (e.g., `192.168.122.151` in the example above).
-
-We are using vulnerable Linux systems running in Virtual Machines for SSH testing. Never run this against real production systems.
-
-> 💡 **We also provide vulnerable machines!**
->
-> We are using virtual machines from our [Linux Privilege-Escalation Benchmark](https://github.com/ipa-lab/benchmark-privesc-linux) project. Feel free to use them for your own research!
-
-## Viewing and analyzing logs
-
-Each run writes a single append-only file `logs/log-<timestamp>.jsonl` (the timestamp is the run
-start time). Every line is a complete OpenTelemetry span using the GenAI semantic conventions
-(`gen_ai.*`); LLM prompts/completions are stored as structured message parts, a shape that also
-matches the OWASP Agent Observability Standard (AOS). The format is self-contained, so the files
-can be inspected directly or fed into external OpenTelemetry tooling.
-
-Two CLI tools ship for working with these logs:
-
-```bash
-# re-render a single run to the terminal (rich panels, in run order)
-$ hackingbuddygpt-log-view logs/log-20260810-094141.jsonl
-
-# aggregate one or more runs into a stats table (duration, LLM calls, tokens, cost, tool calls)
-$ hackingbuddygpt-log-analyze logs/*.jsonl
-
-# emit a paper-ready LaTeX tabular instead, optionally filtered by model / minimum duration
-$ hackingbuddygpt-log-analyze logs/*.jsonl --latex --model gpt-4o --min-duration 30
-```
-
-## Benchmarking against a fleet of Docker targets
-
-For regression testing and quick experiments we ship a small benchmark launcher,
-`benchmark_privesc.py`, in the repository root. It attacks a fleet of **locally running Docker
-containers** whose image names start with `privesc_` (for example the vulnerable boxes from our
-[Linux Privilege-Escalation Benchmark](https://github.com/ipa-lab/benchmark-privesc-linux)),
-runs a privilege-escalation use-case once against each, and produces a report.
-
-For every matching, running container it:
-
-1. discovers the container and its published SSH port automatically from `docker ps`,
-2. runs the use-case via `wintermute` with a selectable LLM and a per-run turn budget (`--rounds`),
-3. scores the run by reading back its OpenTelemetry/GenAI JSONL trace (a box counts as rooted when
-   the trace's final state is `got root`), and
-4. writes a Markdown `report.md` plus the per-run JSONL traces and console logs under
-   `benchmark_results/<timestamp>/`, alongside a console summary of rooted/failed systems and token
-   cost.
-
-You can drive it with a **local [Ollama](https://ollama.com/) model** (the default, no API key
-needed) or with **[OpenRouter](https://openrouter.ai/)**. Run it from inside the project
-virtualenv so `hackingBuddyGPT` is importable:
-
-```bash
-# make sure the target containers are running first, e.g. the privesc benchmark images
-$ docker ps --format '{{.Names}}\t{{.Image}}'   # images should start with 'privesc_'
-
-# option A: local Ollama model (default provider, no API key required)
-$ uv run benchmark_privesc.py --provider ollama --model ollama_chat/llama3 --rounds 20
-
-# option B: OpenRouter (pass --api-key or set $OPENROUTER_API_KEY)
-$ uv run benchmark_privesc.py --provider openrouter \
-      --model openrouter/anthropic/claude-3.5-sonnet --api-key sk-or-... --rounds 20
-```
-
-Useful options (see `benchmark_privesc.py --help` for the full list):
-
-- `--use-case` — which privesc use-case to launch (default `MinimalPrivEscLinux`; the
-  function-calling prototype is `MinimalToolCallPrivEscLinux`).
-- `--filter SUBSTR` — only run containers whose name/image contains `SUBSTR`.
-- `--trials N` — run each container `N` times (useful for measuring variance).
-- `--rounds N` — per-run turn budget (mapped automatically to `--max_turns` or
-  `--limits.max_rounds` depending on the use-case).
-- `--max-cost`, `--run-timeout` — optional per-run cost cap and wall-clock timeout.
-- `--ollama-host`, `--or-provider` — Ollama base URL / OpenRouter provider routing.
-- `--username`, `--password`, `--ssh-host` — SSH credentials/host for the target containers
-  (default `lowpriv` / `trustno1` on `127.0.0.1`).
-
-## Run the Hacking Agent
-
-Finally we can run hackingBuddyGPT against our provided test VM. Enjoy!
-
-> ❗ **Don't be evil!**
->
-> Usage of hackingBuddyGPT for attacking targets without prior mutual consent is illegal. It's the end user's responsibility to obey all applicable local, state and federal laws. Developers assume no liability and are not responsible for any misuse or damage caused by this program. Only use for educational purposes.
-
-With that out of the way, let's look at an example hackingBuddyGPT run. Each run is structured in rounds. At the start of each round, hackingBuddyGPT asks a LLM for the next command to execute (e.g., `whoami`) for the first round. It then executes that command on the virtual machine, prints its output and starts a new round (in which it also includes the output of prior rounds) until it reaches step number 10 or becomes root:
-
-```bash
-# Example 1: Using local shell with tmux session
-# First create the tmux session: tmux new-session -s hacking_session
-# Then run hackingBuddyGPT:
-$ wintermute PrivEscLinux --llm.api_key=sk...ChangeMeToYourOpenAiApiKey --llm.model=gpt-4-turbo --llm.context_size=8192 --conn=local_shell --conn.tmux_session=hacking_session
-
-# Example 2: Using SSH connection (updated format)
-$ wintermute PrivEscLinux --llm.api_key=sk...ChangeMeToYourOpenAiApiKey --llm.model=gpt-4-turbo --llm.context_size=8192 --conn=ssh --conn.host=192.168.122.151 --conn.username=lowpriv --conn.password=trustno1 --conn.hostname=test1
-
-# install dependencies for testing if you want to run the tests
-$ uv sync --extra testing   # or: pip install '.[testing]'
-```
-
-## Publications about hackingBuddyGPT
-
-Given our background in academia, we have authored papers that lay the groundwork and report on our efforts:
+Further papers that lay the groundwork and report on our efforts:
 
 - [Understanding Hackers' Work: An Empirical Study of Offensive Security Practitioners](https://arxiv.org/abs/2308.07057), presented at [FSE'23](https://2023.esec-fse.org/)
-- [Getting pwn'd by AI: Penetration Testing with Large Language Models](https://arxiv.org/abs/2308.00121), presented at [FSE'23](https://2023.esec-fse.org/) 
-- [Got root? A Linux Privilege-Escalation Benchmark](https://arxiv.org/abs/2405.02106), currently searching for a suitable conference/journal
-- [LLMs as Hackers: Autonomous Linux Privilege Escalation Attacks](https://arxiv.org/abs/2310.11409), currently searching for a suitable conference/journal
+- [Getting pwn'd by AI: Penetration Testing with Large Language Models](https://arxiv.org/abs/2308.00121), presented at [FSE'23](https://2023.esec-fse.org/)
+- [Got root? A Linux Privilege-Escalation Benchmark](https://arxiv.org/abs/2405.02106)
+- [LLMs as Hackers: Autonomous Linux Privilege Escalation Attacks](https://arxiv.org/abs/2310.11409)
 
-# Disclaimers
+## Disclaimers
 
-Please note and accept all of them.
+**No warranty.** This project is an experimental application provided "as-is" without any warranty, express or implied. By using this software you assume all risks associated with its use, including but not limited to data loss, system failure, or any other issues that may arise. The developers and contributors accept no responsibility or liability for any losses, damages, or other consequences resulting from its use.
 
-### Disclaimer 1
+**Costs are your responsibility.** LLM usage can be expensive due to token consumption. You are responsible for monitoring and managing your own usage and costs — set up limits and alerts, and use the `--limits.max_cost` / `--limits.max_tokens` caps.
 
-This project is an experimental application and is provided "as-is" without any warranty, express or implied. By using this software, you agree to assume all risks associated with its use, including but not limited to data loss, system failure, or any other issues that may arise.
-
-The developers and contributors of this project do not accept any responsibility or liability for any losses, damages, or other consequences that may occur as a result of using this software. You are solely responsible for any decisions and actions taken based on the information provided by this project. 
-
-**Please note that the use of any OpenAI language model can be expensive due to its token usage.** By utilizing this project, you acknowledge that you are responsible for monitoring and managing your own token usage and the associated costs. It is highly recommended to check your OpenAI API usage regularly and set up any necessary limits or alerts to prevent unexpected charges.
-
-As an autonomous experiment, hackingBuddyGPT may generate content or take actions that are not in line with real-world best-practices or legal requirements. It is your responsibility to ensure that any actions or decisions made based on the output of this software comply with all applicable laws, regulations, and ethical standards. The developers and contributors of this project shall not be held responsible for any consequences arising from the use of this software.
-
-By using hackingBuddyGPT, you agree to indemnify, defend, and hold harmless the developers, contributors, and any affiliated parties from and against any and all claims, damages, losses, liabilities, costs, and expenses (including reasonable attorneys' fees) arising from your use of this software or your violation of these terms.
-
-### Disclaimer 2
-
-The use of hackingBuddyGPT for attacking targets without prior mutual consent is illegal. It's the end user's responsibility to obey all applicable local, state, and federal laws. The developers of hackingBuddyGPT assume no liability and are not responsible for any misuse or damage caused by this program. Only use it for educational purposes.
+**Legal & ethical use.** Using hackingBuddyGPT to attack targets without prior mutual consent is illegal. It is the end user's responsibility to obey all applicable local, state and federal laws. The developers assume no liability and are not responsible for any misuse or damage caused by this program. **Only use it for educational purposes and against systems you are authorized to test. Don't be evil.**


### PR DESCRIPTION
Rewrite README to a quickstart-first structure and bring it in line with the current code:

- badge row (license/python/CI/docs/GHCR) + tighter intro
- accurate use-case matrix for all 10 registered use-cases, incl. Windows privesc, the tool-calling privesc twin, and the AD assumed-breach agent
- reframe LLM setup around litellm (OpenRouter default, Ollama, proxy support) instead of the old OpenAI-only story; regenerate the --help excerpt
- new Docker/GHCR section; real MinimalPrivEscLinux code sample (was the removed synchronous Agent API)
- condensed news + disclaimers

.env.example: drop removed log_db (SQLite) and stale RAG keys; align with litellm/OpenRouter config, limits.*, and --rag_path.


Claude-Session: https://claude.ai/code/session_01MFggLf7btQeXve9BxcbN6m